### PR TITLE
Test inside container

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,26 +82,33 @@ jobs:
         run: |
           sudo apt install dnf systemd-container
           sudo apt install postgresql-client
-          sudo ./tests/scripts/setup_fedora_container.sh
-          sudo apt install curl ca-certificates gnupg
-          sudo apt install python3-bpfcc python3-pip telnet
           # Also install it in the host, for the tests running outside the
           # container
           sudo pip install setuptools toml
+          sudo apt install python3-bpfcc python3-pip telnet
           python -c 'import toml; open("requirements.txt.tmp", "w").write("\n".join(toml.load(open("pyproject.toml"))["project"]["dependencies"]) + "\n")'
           # Install lint requirements
           python -c 'import toml; open("requirements.txt.tmp", "a").write("\n".join(toml.load(open("pyproject.toml"))["project"]["optional-dependencies"]["lint"]) + "\n")'
           sudo pip install -r requirements.txt.tmp
+          sudo ./tests/scripts/setup_fedora_container.sh
+          sudo apt install curl ca-certificates gnupg
 
-      - id: fedora_tests
+      - id: fedora_tests_outside_container
         run: |
           sudo PYTHONPATH=$(pwd)/src pytest --postgresql-host 172.16.0.1 --container fedora --cov --cov-report=xml
+
+      - id: fedora_tests_inside_container
+        run: |
+          sudo systemd-run --setenv=PYTHONPATH=/root/pgtracer/src \
+            --working-directory=/root/pgtracer  \
+            --machine fedora --wait --pipe \
+            pytest --postgresql-exec /usr/bin/pg_ctl  --cov --cov-report=xml
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         with:
           env_vars: PGVERSION, DISTRO
           fail_ci_if_error: true
-          files: ./coverage.xml
+          files: ./coverage.xml /var/lib/machines/fedora/root/ptracer/coverage.xml
           verbose: true
           name: codecov

--- a/tests/scripts/setup_fedora_container.sh
+++ b/tests/scripts/setup_fedora_container.sh
@@ -33,6 +33,7 @@ dnf -y --releasever=36 --best \
   install \
   dhcp-client dnf fedora-release glibc glibc-langpack-en glibc-langpack-de \
   iputils less ncurses passwd systemd \
+  kernel-devel \
   systemd-networkd systemd-resolved util-linux vim-default-editor \
   postgresql-server dnf-utils dnf-plugins-core \
   python-bcc python-pip
@@ -42,6 +43,10 @@ cp /etc/resolv.conf /var/lib/machines/fedora/etc/resolve.conf
 
 systemd-nspawn -D /var/lib/machines/fedora/ /usr/bin/dnf --best -y --releasever=36 install postgresql-server
 systemd-nspawn -D /var/lib/machines/fedora/ /usr/bin/dnf -y --releasever=36 debuginfo-install postgresql-server
+
+systemd-nspawn -D /var/lib/machines/fedora/ /usr/bin/pip install toml setuptools
+cp -r ./ /var/lib/machines/fedora/root/pgtracer/
+systemd-nspawn -D /var/lib/machines/fedora/ /usr/bin/pip install -r /root/pgtracer/requirements.txt.tmp
 
 # Set a dummy password for the root user
 systemd-nspawn --console=pipe -D /var/lib/machines/fedora/ passwd root --stdin << EOF
@@ -59,6 +64,9 @@ systemd-run --machine fedora --pipe --wait /usr/bin/systemctl enable postgresql 
 systemd-run --machine fedora --pipe --wait /usr/sbin/ip link set up host0
 systemd-run --machine fedora --pipe --wait /usr/sbin/ip addr add 172.16.0.1/30 dev host0
 systemd-run --machine fedora --pipe --wait /usr/sbin/ip route add default dev host0
+
+# Let's give the container access to the kernel's modules
+cp -rv /lib/modules/$(uname -r) /var/lib/machines/fedora/lib/modules/
 
 # Ok, now we need to assign a static IP address
 ip link   set up ve-fedora


### PR DESCRIPTION
Also run the tests inside the container.

This could help find problems with the python-bcc version shipped by fedora.