### PR TITLE
Ci: refactor pip install logic for test and lint fix #26

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,13 +27,8 @@ jobs:
         run: |
           # Must be installed via the system
           sudo apt install python3-bpfcc python3-pip
-          pip install setuptools toml
-          # Install requirements from pyproject.toml
-          python -c 'import toml; open("requirements.txt.tmp", "w").write("\n".join(toml.load(open("pyproject.toml"))["project"]["dependencies"]) + "\n")'
-          # Install lint requirements
-          python -c 'import toml; open("requirements.txt.tmp", "a").write("\n".join(toml.load(open("pyproject.toml"))["project"]["optional-dependencies"]["lint"]) + "\n")'
-          pip install -r requirements.txt.tmp
-          python -c "import bcc; print(bcc.__file__)"
+          pip install -U pip toml
+          pip install '.[lint]'
 
       - id: pylint
         run: pylint --rcfile .pylintrc src/ || pylint-exit $? -efail

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,18 +44,14 @@ jobs:
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-${{ matrix.repo }} main ${{ matrix.postgresql_version }}" > /etc/apt/sources.list.d/pgdg.list'
           sudo apt update
           sudo apt install postgresql-${{matrix.postgresql_version}} postgresql-${{matrix.postgresql_version}}-dbgsym
-          sudo pip install setuptools toml
-
+          sudo pip install -U pip toml
           # Install requirements from pyproject.toml
-          python -c 'import toml; open("requirements.txt.tmp", "w").write("\n".join(toml.load(open("pyproject.toml"))["project"]["dependencies"]) + "\n")'
-          # Install lint requirements
-          python -c 'import toml; open("requirements.txt.tmp", "a").write("\n".join(toml.load(open("pyproject.toml"))["project"]["optional-dependencies"]["lint"]) + "\n")'
-          sudo pip install -r requirements.txt.tmp
+          sudo pip install '.[test]'
           python -c "import bcc; print(bcc.__file__)"
 
       - id: tests
         run: |
-          sudo PYTHONPATH=$(pwd)/src pytest --postgresql-exec /usr/lib/postgresql/${{matrix.postgresql_version}}/bin/pg_ctl --cov --cov-report=xml
+          sudo pytest --postgresql-exec /usr/lib/postgresql/${{matrix.postgresql_version}}/bin/pg_ctl --cov --cov-report=xml
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
@@ -85,15 +81,12 @@ jobs:
           sudo apt install python3-bpfcc python3-pip libunwind-dev linux-headers-$(uname -r)
           # Also install it in the host, for the tests running outside the
           # container
-          sudo pip install setuptools toml
-          python -c 'import toml; open("requirements.txt.tmp", "w").write("\n".join(toml.load(open("pyproject.toml"))["project"]["dependencies"]) + "\n")'
-          # Install lint requirements
-          python -c 'import toml; open("requirements.txt.tmp", "a").write("\n".join(toml.load(open("pyproject.toml"))["project"]["optional-dependencies"]["lint"]) + "\n")'
-          sudo pip install -r requirements.txt.tmp
+          sudo pip install -U pip toml
+          sudo pip install '.[test]'
 
       - id: fedora_tests
         run: |
-          sudo PYTHONPATH=$(pwd)/src pytest --postgresql-host 172.16.0.1 --container fedora --cov --cov-report=xml
+          sudo pytest --postgresql-host 172.16.0.1 --container fedora --cov --cov-report=xml
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,12 @@ lint = [
   'black',
   'isort',
   'mypy',
-  'psycopg',
   'pylint',
   'pylint-exit',
+]
+
+test = [
+  'psycopg',
   'pytest',
   'pytest-coverage',
   'pytest-postgresql',


### PR DESCRIPTION
fix: #26 
refactor pip install logic for test and lint
for `pyproject.toml`  repo there is an easy way to install
this `PR` make the GitHub Actions cleaner.
my passed job can check https://github.com/yihong0618/pgtracer/actions/runs/3367072889/jobs/5584216925
the reason this Actions failed is that I can not upload coverage reports to `Codecov`