### PR TITLE
Live query plan

### DIFF
--- a/src/pgtracer/ebpf/collector.py
+++ b/src/pgtracer/ebpf/collector.py
@@ -792,8 +792,8 @@ class BPF_Collector:
         path: List[str],
     ) -> memory_request:
         """
-        Build a memory request from a requestId, a base_addr, a known base_type living at this addr and a path
-        describing which fields to follow to the final memory location.
+        Build a memory request from a requestId, a base_addr, a known base_type living
+        at this addr and a path describing which fields to follow to the final memory location.
 
         The fields definitions are extracted from the debug symbols.
         """

--- a/src/pgtracer/ebpf/collector.py
+++ b/src/pgtracer/ebpf/collector.py
@@ -255,11 +255,7 @@ class EventHandler:
         event_type_name = EventType(event_type).name
         method_name = f"handle_{event_type_name}"
         method: Callable[[BPF_Collector, ct._CData], int] = getattr(self, method_name)
-
-        if method:
-            return method(bpf_collector, event)
-
-        return 0
+        return method(bpf_collector, event)
 
     def handle_ExecutorRun(self, bpf_collector: BPF_Collector, event: ct._CData) -> int:
         """

--- a/src/pgtracer/ebpf/dwarf.py
+++ b/src/pgtracer/ebpf/dwarf.py
@@ -141,12 +141,11 @@ def get_size(
     """
     if issubclass(to_size, Struct):
         return to_size.size()
-    elif issubclass(to_size, DWARFPointer):
+    if issubclass(to_size, DWARFPointer):
         if dereference:
             return get_size(to_size.pointed_type)
         return ct.sizeof(ct.c_void_p)
-    else:
-        return ct.sizeof(to_size)
+    return ct.sizeof(to_size)
 
 
 def find_debuginfo(

--- a/src/pgtracer/scripts/pgtrace_queries.py
+++ b/src/pgtracer/scripts/pgtrace_queries.py
@@ -98,7 +98,7 @@ def print_running_query(
         if not print_plan:
             print("Tuples produced / tuple expected")
             print("")
-    for i in range(clear_line):
+    for _ in range(clear_line):
         print(LINE_UP, end=LINE_CLEAR)
     if print_plan:
         plan = query.root_node.explain()

--- a/tests/test_ebpf.py
+++ b/tests/test_ebpf.py
@@ -70,7 +70,7 @@ def test_instrumentation(bpfcollector_instrumented, connection):
     assert 0 <= query.shared_buffers_hitratio < 100
     # The syscache_hitratio can be negative, when we actually end up reading
     # more blocks than what is accounted for by instrumentation.
-    assert query.syscache_hitratio < 100
+    assert query.syscache_hitratio <= 100
 
     # Check that we don't crash without any instrumentation whatshowever
     query.instrument = None


### PR DESCRIPTION
Dump the currently executing query plan.

Note: pgtracer must have been started prior to the query, for now. An additional PR will come to discover the current query.