### PR TITLE
Fix handling of instrumentation times

### DIFF
--- a/src/pgtracer/ebpf/dwarf.py
+++ b/src/pgtracer/ebpf/dwarf.py
@@ -858,7 +858,7 @@ class ProcessMetadata:
         gdb_type = GDB_INDEX_TYPES_MAPPING.get(tag)
         matching_dies_offsets = set()
         matching_dies_list = []
-        for (cuidx, _type) in cu_vector:
+        for cuidx, _type in cu_vector:
             if gdb_type is not None and gdb_type != _type:
                 continue
             cu_offset = self.gdb_index.cu_offset_by_idx(cuidx)

--- a/src/pgtracer/ebpf/dwarf.py
+++ b/src/pgtracer/ebpf/dwarf.py
@@ -633,11 +633,16 @@ class Structs:
             return self.cache[attrname]
 
         # Ok, build the class.
-        die = next(self.metadata.search_symbol("DW_TAG_structure_type", attrname))
-        cls = type(attrname, (Struct,), {"metadata": self.metadata, "die": die})
-        self.cache[attrname] = cls
-
-        return cls
+        for die in self.metadata.search_symbol("DW_TAG_structure_type", attrname):
+            if (
+                "DW_AT_declaration" in die.attributes
+                and die.attributes["DW_AT_declaration"]
+            ):
+                continue
+            cls = type(attrname, (Struct,), {"metadata": self.metadata, "die": die})
+            self.cache[attrname] = cls
+            return cls
+        raise ValueError(f"Could not find type for {attrname}")
 
 
 class CacheJSONEncoder(json.JSONEncoder):

--- a/src/pgtracer/ebpf/unwind.py
+++ b/src/pgtracer/ebpf/unwind.py
@@ -495,7 +495,7 @@ class Frame:
         Read an argument of givent type at the given offset from the stack.
         """
         assert 0 <= offset < len(self.stack)  # type: ignore
-        return ctype.from_buffer(bytearray(self.stack)[offset:])  # type: ignore
+        return ctype.from_buffer(bytearray(self.stack)[offset:])
 
     def eval_expr(
         self, expr: DWARFExprOp, ctype: Type[CT], dwarf_stack: List[CT]

--- a/src/pgtracer/utils.py
+++ b/src/pgtracer/utils.py
@@ -17,19 +17,28 @@ else:
 
 def timespec_to_timedelta(timespec: _CData) -> timedelta:
     """
-    Convert a timespec_t struct to a timedelta.
+    Convert a timespec_t or instr_time struct to a timedelta.
     """
-    return timedelta(
-        seconds=timespec.tv_sec.value,  # type: ignore
-        microseconds=timespec.tv_nsec.value / 1000,  # type: ignore
-    )
+    # Can't really compare it to a proper class, so test on the class name
+    if timespec.__class__.__name__ == "timespec":
+        return timedelta(
+            seconds=timespec.tv_sec.value,  # type: ignore
+            microseconds=timespec.tv_nsec.value / 1000,  # type: ignore
+        )
+    if timespec.__class__.__name__ == "instr_time":
+        return timedelta(seconds=timespec.ticks.value / 1000000000)  # type: ignore
+    raise ValueError("Expecting a timespec or instr_time struct")
 
 
 def timespec_to_float(timespec: _CData) -> float:
     """
-    Convert a timespec_t struct to a float representing the number of seconds.
+    Convert a timespec_t or instr_time struct to a float representing the number of seconds.
     """
-    return float(timespec.tv_sec.value + timespec.tv_nsec.value / 1000000000)  # type: ignore
+    if timespec.__class__.__name__ == "timespec":
+        return float(timespec.tv_sec.value + timespec.tv_nsec.value / 1000000000)  # type: ignore
+    if timespec.__class__.__name__ == "instr_time":
+        return float(timespec.ticks.value / 1000000000)  # type: ignore
+    raise ValueError("Expecting a timespec or instr_time struct")
 
 
 NSPID_PARSING_RE = re.compile(rb"^NSpid:\s+((?:(?:\d+)\s*)+)")


### PR DESCRIPTION
With PG16, instrumentation times are now in an instr_time struct instead of a timespec. Handle both cases.